### PR TITLE
Move category widget out of advance search form

### DIFF
--- a/lib/src/ui/advanced_search_form.dart
+++ b/lib/src/ui/advanced_search_form.dart
@@ -27,6 +27,7 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
   final dateFormat = DateFormat('yyyy-MM-dd');
   final TextEditingController _controller = new TextEditingController();
   DateTime _startDate;
+  bool categoryIsExpanded = true;
 
   @override
   Widget build(BuildContext context) {
@@ -80,19 +81,13 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
                   },
                 ),
                 SizedBox(height: 8.0),
-                FlatButton(
-                  child: Text(SearchAppLocalizations.of(context).resetText),
-                  onPressed: () {
-                    setState(() {
-                      _formResult = SearchParameters();
-                    });
-                  },
-                ),
                 ExpansionTile(
                   initiallyExpanded: true,
                   title: Text(SearchAppLocalizations
                       .of(context)
-                      .categoryTitle),
+                      .categoryTitle,
+                      style: TextStyle(color: this.categoryIsExpanded ? Colors.transparent :  Colors.black)),
+                  onExpansionChanged: (bool expanding) => setState(() => this.categoryIsExpanded = expanding),
                   children: [
                     Query(
                         options: QueryOptions(
@@ -186,6 +181,14 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
                   children: [
                     Column(
                       children: [
+                        FlatButton(
+                          child: Text(SearchAppLocalizations.of(context).resetText),
+                          onPressed: () {
+                            setState(() {
+                              _formResult = SearchParameters();
+                            });
+                          },
+                        ),
                         Query(
                           options: QueryOptions(
                             documentNode: gql(facetsQuery),

--- a/lib/src/ui/advanced_search_form.dart
+++ b/lib/src/ui/advanced_search_form.dart
@@ -81,99 +81,59 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
                   },
                 ),
                 SizedBox(height: 8.0),
-                ExpansionTile(
-                  initiallyExpanded: true,
-                  title: Text(SearchAppLocalizations
-                      .of(context)
-                      .categoryTitle,
-                      style: TextStyle(color: this.categoryIsExpanded ? Colors.transparent :  Colors.black)),
-                  onExpansionChanged: (bool expanding) => setState(() => this.categoryIsExpanded = expanding),
-                  children: [
-                    Query(
-                        options: QueryOptions(
-                          documentNode: gql(facetsQuery),
-                          variables: queryVariables(
-                              Localizations.localeOf(context).languageCode,
-                              _formResult.ageGroupsServed,
-                              _formResult.acceptingNewClients,
-                              _formResult.servicesAreProvided,
-                              _formResult.keyword,
-                              _formResult.languages,
-                              _formResult.chapters,
-                              _formResult.catagories,
-                              Localizations.localeOf(context).languageCode.toUpperCase(),
-                              _formResult.isVerified,
-                              _formResult.startDate,
-                              _formResult.endDate,
-                              true
-                          ),
-                        ),
-                        builder: (QueryResult result, {VoidCallback refetch, FetchMore fetchMore}) {
-                          var catagories = new List();
-                          if (result.loading) {
-                            catagories = _loadedResult.catagories;
-                          }
-                          else if (result.hasException || result.data["searchAPISearch"] == null) {
-                            _formResult.catagories = new List();
-                          }
-                          else {
-                            if (getCatagories(translation, result.data["searchAPISearch"]["facets"], false).isEmpty) {
-                              _formResult.catagories = new List();
-                            }
-                            else {
-                              catagories = getCatagories(translation, result.data["searchAPISearch"]["facets"], false);
-                            }
-                          }
-                          List<Widget> catagoryList = [];
-                          for (var catagory in catagories) {
-                            catagoryList.add(new ListTile(
-                              title: new Row(
-                                children: <Widget>[
-                                  new Expanded(child: new Text(catagory['entityLabel'])),
-                                  new Checkbox(
-                                      value: _formResult.catagories == null ? false : _formResult.catagories.contains(catagory['entityId']) ? true : false,
-                                      onChanged: (bool value) {
-                                        setState(() {
-                                          if (value) {
-                                            if (_formResult.catagories == null) {
-                                              _formResult.catagories = new List();
-                                            }
-                                            _formResult.catagories.add(catagory['entityId']);
-                                          }
-                                          else {
-                                            _formResult.catagories = null;
-                                          }
-                                        });
-                                      })
-                                ],
-                              )
-                            )
-                            );
-                          }
-                          /*
-                          return Column(
-                            children: catagoryList,
-                          );
-                          */
-                          return MultiSelectFormField(
-                            initialValue: _formResult.catagories,
-                            title: Text(SearchAppLocalizations
-                                .of(context)
-                                .categoryTitle),
-                            dataSource: catagories,
-                            valueField: 'entityId',
-                            textField: 'entityLabel',
-                            onSaved: (values) {
-                              setState(() {
-                                _formResult.catagories = values;
-                              });
-                            },
-                            hintWidget: Text(SearchAppLocalizations
-                                .of(context).categoryHintText),
-                          );
-                        }
+                Query(
+                    options: QueryOptions(
+                      documentNode: gql(facetsQuery),
+                      variables: queryVariables(
+                          Localizations.localeOf(context).languageCode,
+                          _formResult.ageGroupsServed,
+                          _formResult.acceptingNewClients,
+                          _formResult.servicesAreProvided,
+                          _formResult.keyword,
+                          _formResult.languages,
+                          _formResult.chapters,
+                          _formResult.catagories,
+                          Localizations.localeOf(context).languageCode.toUpperCase(),
+                          _formResult.isVerified,
+                          _formResult.startDate,
+                          _formResult.endDate,
+                          true
+                      ),
                     ),
-                  ],
+                    builder: (QueryResult result, {VoidCallback refetch, FetchMore fetchMore}) {
+                      var catagories = new List();
+                      if (result.loading) {
+                        catagories = _loadedResult.catagories;
+                      }
+                      else if (result.hasException || result.data["searchAPISearch"] == null) {
+                        _formResult.catagories = new List();
+                      }
+                      else {
+                        if (getCatagories(translation, result.data["searchAPISearch"]["facets"], false).isEmpty) {
+                          _formResult.catagories = new List();
+                        }
+                        else {
+                          catagories = getCatagories(translation, result.data["searchAPISearch"]["facets"], false);
+                        }
+                      }
+
+                      return MultiSelectFormField(
+                        initialValue: _formResult.catagories,
+                        title: Text(SearchAppLocalizations
+                            .of(context)
+                            .categoryTitle),
+                        dataSource: catagories,
+                        valueField: 'entityId',
+                        textField: 'entityLabel',
+                        onSaved: (values) {
+                          setState(() {
+                            _formResult.catagories = values;
+                          });
+                        },
+                        hintWidget: Text(SearchAppLocalizations
+                            .of(context).categoryHintText),
+                      );
+                    }
                 ),
                 SizedBox(height: 8.0),
                 ExpansionTile(

--- a/lib/src/ui/advanced_search_form.dart
+++ b/lib/src/ui/advanced_search_form.dart
@@ -27,8 +27,7 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
   final dateFormat = DateFormat('yyyy-MM-dd');
   final TextEditingController _controller = new TextEditingController();
   DateTime _startDate;
-  bool categoryIsExpanded = true;
-
+  
   @override
   Widget build(BuildContext context) {
     SearchParameters _loadedResult = widget.search;

--- a/lib/src/ui/advanced_search_form.dart
+++ b/lib/src/ui/advanced_search_form.dart
@@ -80,72 +80,112 @@ class _AdvancedSearchFormState extends State<AdvancedSearchForm> {
                   },
                 ),
                 SizedBox(height: 8.0),
+                FlatButton(
+                  child: Text(SearchAppLocalizations.of(context).resetText),
+                  onPressed: () {
+                    setState(() {
+                      _formResult = SearchParameters();
+                    });
+                  },
+                ),
+                ExpansionTile(
+                  initiallyExpanded: true,
+                  title: Text(SearchAppLocalizations
+                      .of(context)
+                      .categoryTitle),
+                  children: [
+                    Query(
+                        options: QueryOptions(
+                          documentNode: gql(facetsQuery),
+                          variables: queryVariables(
+                              Localizations.localeOf(context).languageCode,
+                              _formResult.ageGroupsServed,
+                              _formResult.acceptingNewClients,
+                              _formResult.servicesAreProvided,
+                              _formResult.keyword,
+                              _formResult.languages,
+                              _formResult.chapters,
+                              _formResult.catagories,
+                              Localizations.localeOf(context).languageCode.toUpperCase(),
+                              _formResult.isVerified,
+                              _formResult.startDate,
+                              _formResult.endDate,
+                              true
+                          ),
+                        ),
+                        builder: (QueryResult result, {VoidCallback refetch, FetchMore fetchMore}) {
+                          var catagories = new List();
+                          if (result.loading) {
+                            catagories = _loadedResult.catagories;
+                          }
+                          else if (result.hasException || result.data["searchAPISearch"] == null) {
+                            _formResult.catagories = new List();
+                          }
+                          else {
+                            if (getCatagories(translation, result.data["searchAPISearch"]["facets"], false).isEmpty) {
+                              _formResult.catagories = new List();
+                            }
+                            else {
+                              catagories = getCatagories(translation, result.data["searchAPISearch"]["facets"], false);
+                            }
+                          }
+                          List<Widget> catagoryList = [];
+                          for (var catagory in catagories) {
+                            catagoryList.add(new ListTile(
+                              title: new Row(
+                                children: <Widget>[
+                                  new Expanded(child: new Text(catagory['entityLabel'])),
+                                  new Checkbox(
+                                      value: _formResult.catagories == null ? false : _formResult.catagories.contains(catagory['entityId']) ? true : false,
+                                      onChanged: (bool value) {
+                                        setState(() {
+                                          if (value) {
+                                            if (_formResult.catagories == null) {
+                                              _formResult.catagories = new List();
+                                            }
+                                            _formResult.catagories.add(catagory['entityId']);
+                                          }
+                                          else {
+                                            _formResult.catagories = null;
+                                          }
+                                        });
+                                      })
+                                ],
+                              )
+                            )
+                            );
+                          }
+                          /*
+                          return Column(
+                            children: catagoryList,
+                          );
+                          */
+                          return MultiSelectFormField(
+                            initialValue: _formResult.catagories,
+                            title: Text(SearchAppLocalizations
+                                .of(context)
+                                .categoryTitle),
+                            dataSource: catagories,
+                            valueField: 'entityId',
+                            textField: 'entityLabel',
+                            onSaved: (values) {
+                              setState(() {
+                                _formResult.catagories = values;
+                              });
+                            },
+                            hintWidget: Text(SearchAppLocalizations
+                                .of(context).categoryHintText),
+                          );
+                        }
+                    ),
+                  ],
+                ),
+                SizedBox(height: 8.0),
                 ExpansionTile(
                   title: Text(SearchAppLocalizations.of(context).advSearchTitle),
                   children: [
                     Column(
                       children: [
-                        FlatButton(
-                          child: Text(SearchAppLocalizations.of(context).resetText),
-                          onPressed: () {
-                            setState(() {
-                              _formResult = SearchParameters();
-                            });
-                          },
-                        ),
-                        Query(
-                            options: QueryOptions(
-                              documentNode: gql(facetsQuery),
-                              variables: queryVariables(
-                                Localizations.localeOf(context).languageCode,
-                                _formResult.ageGroupsServed,
-                                _formResult.acceptingNewClients,
-                                _formResult.servicesAreProvided,
-                                _formResult.keyword,
-                                _formResult.languages,
-                                _formResult.chapters,
-                                _formResult.catagories,
-                                Localizations.localeOf(context).languageCode.toUpperCase(),
-                                _formResult.isVerified,
-                                _formResult.startDate,
-                                _formResult.endDate,
-                                true
-                              ),
-                            ),
-                            builder: (QueryResult result, {VoidCallback refetch, FetchMore fetchMore}) {
-                              var catagories = new List();
-                              if (result.loading) {
-                                catagories = _loadedResult.catagories;
-                              }
-                              else if (result.hasException || result.data["searchAPISearch"] == null) {
-                                _formResult.catagories = new List();
-                              }
-                              else {
-                                if (getCatagories(translation, result.data["searchAPISearch"]["facets"], false).isEmpty) {
-                                  _formResult.catagories = new List();
-                                }
-                                else {
-                                  catagories = getCatagories(translation, result.data["searchAPISearch"]["facets"], false);
-                                }
-                              }
-                              return MultiSelectFormField(
-                                initialValue: _formResult.catagories,
-                                title: Text(SearchAppLocalizations
-                                    .of(context)
-                                    .categoryTitle),
-                                dataSource: catagories,
-                                valueField: 'entityId',
-                                textField: 'entityLabel',
-                                onSaved: (values) {
-                                  setState(() {
-                                    _formResult.catagories = values;
-                                  });
-                                },
-                                hintWidget: Text(SearchAppLocalizations
-                                    .of(context).categoryHintText),
-                              );
-                            }
-                        ),
                         Query(
                           options: QueryOptions(
                             documentNode: gql(facetsQuery),

--- a/lib/src/ui/full_search_result.dart
+++ b/lib/src/ui/full_search_result.dart
@@ -109,6 +109,7 @@ class FullResultsPage extends StatelessWidget {
                               ]
                             )
                           ),
+                          SizedBox(height: 10.0),
                           Query(
                             options: QueryOptions(
                               documentNode: gql(optionValueQuery),
@@ -122,7 +123,7 @@ class FullResultsPage extends StatelessWidget {
                                 return Text('Loading');
                               }
                               return ListTile(
-                                  title: Row(children :buildRegulatorServiceProvided(result1.data["civicrmOptionValueJmaQuery"]['entities'], result.data['civicrmRelationshipJmaQuery']['entities'], Localizations.localeOf(context).languageCode.toUpperCase(), isVerified))
+                                  title: Column(children :buildRegulatorServiceProvided(result1.data["civicrmOptionValueJmaQuery"]['entities'], result.data['civicrmRelationshipJmaQuery']['entities'], Localizations.localeOf(context).languageCode.toUpperCase(), isVerified))
                               );
                             }
                           ),
@@ -160,6 +161,7 @@ class FullResultsPage extends StatelessWidget {
                               );
                             }
                           ),
+                          SizedBox(height: 10),
                           ListTile(
                             title: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -404,13 +406,28 @@ class FullResultsPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: newRegulators
           ),
+          SizedBox(height: 10.0),
         ],
       ));
     }
-    if (creds.length == 0 && regulators.length == 0) {
-      creds.add(langCode == 'FR' ? 'Aucune de ces réponses' : 'None of the above');
+    var title = Align(
+      alignment: Alignment.centerLeft,
+      child: Text(langCode == 'FR' ? 'Titre(s) de compétence détenu(s): ' : 'Credential(s) held: ', style: TextStyle(fontSize: 15)),
+    );
+    if (creds.length == 0) {
+      var text = langCode == 'FR' ? 'Aucune de ces réponses' : 'None of the above';
+      widgets.add(
+        Column(
+          children: [
+            title,
+            Row(
+                children: [Text(text, style: TextStyle(fontSize: 12))]
+            )
+          ],
+        )
+      );
     }
-    if (creds.length > 0) {
+    else {
       var newCreds = <Row>[], count = 1;
       creds = LinkedHashSet<String>.from(creds).toList();
       for (var cred in creds) {
@@ -419,21 +436,21 @@ class FullResultsPage extends StatelessWidget {
         newCreds.add(Row(
           children: [
             text == 'None of the above' || text == 'Aucune de ces réponses' ? Text('') : Image.asset('images/icon_verified_16px.png'),
-            Text(text,style: TextStyle(fontSize: 12)),
+            Text(text,style: TextStyle(fontSize: 12),),
           ],
         ));
         count++;
       }
-      widgets.add(Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(langCode == 'FR' ? 'Titre(s) de compétence détenu(s): ' : 'Credential(s) held: ', style: TextStyle(fontSize: 15)),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: newCreds
-          ),
-        ],
-      ));
+      widgets.add(
+          Column(
+            children: [
+              title,
+              Row(
+                  children: newCreds
+              )
+            ],
+          )
+      );
     }
 
     return widgets;

--- a/lib/src/ui/full_search_result.dart
+++ b/lib/src/ui/full_search_result.dart
@@ -93,7 +93,7 @@ class FullResultsPage extends StatelessWidget {
                               children: [
                                 Row(
                                   children: [
-                                    Text('SERVICE LISTING',
+                                    Text(translation.serviceListingLabel,
                                       style: TextStyle(
                                         color: Colors.grey[850],
                                         fontStyle: FontStyle.italic,

--- a/lib/src/ui/full_search_result.dart
+++ b/lib/src/ui/full_search_result.dart
@@ -93,7 +93,7 @@ class FullResultsPage extends StatelessWidget {
                               children: [
                                 Row(
                                   children: [
-                                    Text(translation.serviceListingLabel,
+                                    Text(translation.serviceListingLabel.toUpperCase(),
                                       style: TextStyle(
                                         color: Colors.grey[850],
                                         fontStyle: FontStyle.italic,

--- a/lib/src/ui/search_results.dart
+++ b/lib/src/ui/search_results.dart
@@ -242,7 +242,13 @@ class Result extends StatelessWidget {
                     child:  Wrap(
                       spacing: getType(item, true) == 'Service Listing' ? 2 : 0,
                       children: <Widget>[
-                        (getType(item, true) == 'Service Listing' && item["custom_911"] != null && item["custom_911"] != 'None' && item["custom_895"] != null) ? Image.asset('images/icon_verified_16px.png') : Text(''),
+                        (getType(item, true) == 'Service Listing' && (
+                            (item["custom_911"] != null &&
+                                item["custom_911"] != '' &&
+                                item["custom_911"] != 'None'
+                            ) || (item["custom_895"] != null && item["custom_895"] != '')
+                          )
+                        ) ? Image.asset('images/icon_verified_16px.png') : Text(''),
                         Text(
                           getTitle(item),
                           style: TextStyle(

--- a/lib/src/ui/search_results.dart
+++ b/lib/src/ui/search_results.dart
@@ -20,22 +20,22 @@ class ResultsPage extends StatelessWidget {
     return GraphQLProvider(
       client: client,
       child: Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        backgroundColor: Colors.white70,
-        elevation: 4.0,
-        brightness: Brightness.light,
-        iconTheme: IconThemeData(
-          color: Colors.black, //change your color here
+        appBar: AppBar(
+          centerTitle: true,
+          backgroundColor: Colors.white70,
+          elevation: 4.0,
+          brightness: Brightness.light,
+          iconTheme: IconThemeData(
+            color: Colors.black, //change your color here
+          ),
+          title: Image.asset(
+            'images/AO_logo.png',
+            height: AppBar().preferredSize.height,
+            fit: BoxFit.cover,
+          ),
         ),
-        title: Image.asset(
-          'images/AO_logo.png',
-          height: AppBar().preferredSize.height,
-          fit: BoxFit.cover,
-        ),
+        body: new SearchResults(search: search),
       ),
-      body: new SearchResults(search: search),
-    ),
     );
   }
 }
@@ -83,10 +83,10 @@ class _SearchResultsState extends State<SearchResults> {
             legendIconBlock(translation),
             Container(
               child: result.hasException
-                  ? Text(result.exception.toString())
-                  : result.loading
-                    ? Center(child: CircularProgressIndicator())
-                    : result.data["searchAPISearch"]["documents"].length == 0 ? Text(SearchAppLocalizations.of(context).noResultText) : Expanded(child: Result(list: result.data)),
+                ? Text(result.exception.toString())
+                : result.loading
+                ? Center(child: CircularProgressIndicator())
+                : result.data["searchAPISearch"]["documents"].length == 0 ? Text(SearchAppLocalizations.of(context).noResultText) : Expanded(child: Result(list: result.data)),
             )
           ],
         );
@@ -97,85 +97,93 @@ class _SearchResultsState extends State<SearchResults> {
 
   Widget legendIconBlock(translation) {
     const rowSpacer=TableRow(
-        children: [
-          SizedBox(
-            height: 18,
-          ),
-          SizedBox(
-            height: 18,
-          )
-        ]);
+      children: [
+        SizedBox(
+          height: 18,
+        ),
+        SizedBox(
+          height: 18,
+        )
+      ]
+    );
     return SingleChildScrollView(
-        child: Card(
-          child: ExpansionTile(
-            title: Text(translation.serviceLegendTitle),
-            initiallyExpanded: true,
-            children: [
-              SizedBox(height: 10.0),
-              Table(
+      child: Card(
+        child: ExpansionTile(
+          title: Text(translation.serviceLegendTitle),
+          initiallyExpanded: true,
+          children: [
+            SizedBox(height: 10.0),
+            Table(
+              children: [
+                TableRow(
                   children: [
-                    TableRow(children: [
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_accepting_16px.png'),
-                              Text(translation.acceptingNewClientsTitle),
-                            ],
-                          )
-                      ),
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_not_accepting_16px.png'),
-                              Text(translation.notAcceptingNewClients),
-                            ],
-                          )
-                      ),
-                    ]),
-                    rowSpacer,
-                    TableRow(children: [
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_videoconferencing_16px.png'),
-                              Text(translation.online),
-                            ],
-                          )
-                      ),
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_local_travel_16px.png'),
-                              Text(translation.nearbyAreaTravel),
-                            ],
-                          )
-                      ),
-                    ]),
-                    rowSpacer,
-                    TableRow(children: [
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_remote_travel_16px.png'),
-                              Text(translation.removeAreaTravel),
-                            ],
-                          )
-                      ),
-                      TableCell(
-                          child: Column(
-                            children: [
-                              Image.asset('images/icon_verified_16px.png'),
-                              Text(translation.verifiedListing),
-                            ],
-                          )
-                      ),
-                    ]),
-                    rowSpacer,
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_accepting_16px.png'),
+                          Text(translation.acceptingNewClientsTitle),
+                        ],
+                      )
+                    ),
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_not_accepting_16px.png'),
+                          Text(translation.notAcceptingNewClients),
+                        ],
+                      )
+                    ),
                   ]
-              ),
-            ],
-          ))
-        );
+                ),
+                rowSpacer,
+                TableRow(
+                  children: [
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_videoconferencing_16px.png'),
+                          Text(translation.online),
+                        ],
+                      )
+                    ),
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_local_travel_16px.png'),
+                          Text(translation.nearbyAreaTravel),
+                        ],
+                      )
+                    ),
+                  ]
+                ),
+                rowSpacer,
+                TableRow(
+                  children: [
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_remote_travel_16px.png'),
+                          Text(translation.removeAreaTravel),
+                        ],
+                      )
+                    ),
+                    TableCell(
+                      child: Column(
+                        children: [
+                          Image.asset('images/icon_verified_16px.png'),
+                          Text(translation.verifiedListing),
+                        ],
+                      )
+                    ),
+                  ]
+                ),
+                rowSpacer,
+              ]
+            ),
+          ],
+        )
+      )
+    );
   }
 
 class Result extends StatelessWidget {
@@ -185,160 +193,169 @@ class Result extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final translation = SearchAppLocalizations.of(context);
-    var baseURL = getbaseUrl(Localizations.localeOf(context).languageCode.toUpperCase());
+    var baseURL = getBaseUrl(Localizations.localeOf(context).languageCode.toUpperCase());
 
     return ListView.builder(
-        itemCount: list["searchAPISearch"]["documents"].length,
-        itemBuilder: (BuildContext context, int index) {
-          final item = list["searchAPISearch"]["documents"][index];
-          SearchParameters items = SearchParameters();
-          items.catagories = [item['type']];
-          items.keyword = item['title'];
-          String title = getTitle(item);
-          String serviceListingID = item['type'] == null ? getItemId(item).toString() : "0";
-          return Card(
-              elevation: 5,
-              child: Padding(
-              padding: EdgeInsets.all(5),
-                child: Column(
-                  children: [
-                    ListTile(
-                      onTap: () {
-                        var path = '';
-                        var type = getType(item, true);
-                        if (type == 'Service Listing') {
-                          Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => new FullResultsPage(id: getItemId(item).toString())
-                          ));
-                        }
-                        else {
-                          if (type == 'Event') {
-                            path = 'civicrm/event/info?id=';
-                          }
-                          else {
-                            path = 'node/';
-                          }
-                          launch(baseURL + path + getItemId(item).toString());
-                        }
-                      },
-                      title: Container(
-                        padding: EdgeInsets.all(5.0),
-                        height: title.length > 50 ? 100.00 : title.length > 40 ? 80.0 : 50.00,
-                        child:  Wrap(
-                          spacing: getType(item, true) == 'Service Listing' ? 2 : 0,
-                        children: <Widget>[
-                          (getType(item, true) == 'Service Listing' && item["custom_911"] != null && item["custom_911"] != 'None' && item["custom_895"] != null) ? Image.asset('images/icon_verified_16px.png') : Text(''),
-                          Text(
+      itemCount: list["searchAPISearch"]["documents"].length,
+      itemBuilder: (BuildContext context, int index) {
+        final item = list["searchAPISearch"]["documents"][index];
+        SearchParameters items = SearchParameters();
+        items.catagories = [item['type']];
+        items.keyword = item['title'];
+        String title = getTitle(item);
+        String serviceListingID = item['type'] == null ? getItemId(item).toString() : "0";
+        return Card(
+          elevation: 5,
+          child: Padding(
+            padding: EdgeInsets.all(5),
+            child: Column(
+              children: [
+                ListTile(
+                  onTap: () {
+                    var path = '';
+                    var type = getType(item, true);
+                    if (type == 'Service Listing') {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => new FullResultsPage(
+                            id: getItemId(item).toString()
+                          )
+                        )
+                      );
+                    }
+                    else {
+                      if (type == 'Event') {
+                        path = 'civicrm/event/info?id=';
+                      }
+                      else {
+                        path = 'node/';
+                      }
+                      launch(baseURL + path + getItemId(item).toString());
+                    }
+                  },
+                  title: Container(
+                    padding: EdgeInsets.all(5.0),
+                    height: title.length > 50 ? 100.00 : title.length > 40 ? 80.0 : 50.00,
+                    child:  Wrap(
+                      spacing: getType(item, true) == 'Service Listing' ? 2 : 0,
+                      children: <Widget>[
+                        (getType(item, true) == 'Service Listing' && item["custom_911"] != null && item["custom_911"] != 'None' && item["custom_895"] != null) ? Image.asset('images/icon_verified_16px.png') : Text(''),
+                        Text(
                           getTitle(item),
                           style: TextStyle(
-                              color: Colors.grey[850],
-                              fontSize: 18.0,
+                            color: Colors.grey[850],
+                            fontSize: 18.0,
                           ),
                         ),
-                          Divider(
-                            color: Color.fromRGBO(171, 173, 0, 100),
-                            thickness: 3,
-                            endIndent: MediaQuery.of(context).size.width * 0.70,
-                          ),
-                        ]),
-                      ),
-                      subtitle: Wrap(
-                          children: [
-                            Row(
-                                children: [
-                                  Text(getTranslatedTitle(translation, getType(item, false)).toUpperCase(),
-                                    style: TextStyle(
-                                        color: Colors.grey[850],
-                                        fontStyle: FontStyle.italic,
-                                        fontSize: 12.0
-                                    ),
-                                  ),
-                                  Text(' '),
-                                  Query(
-                                      options: QueryOptions(
-                                          documentNode: gql(getServiceListingInformationQuery),
-                                          variables: {"contact_id": serviceListingID, "contactId": serviceListingID}
-                                      ),
-                                      builder: (QueryResult result1, {VoidCallback refetch, FetchMore fetchMore}) {
-                                        if (serviceListingID == "0") {
-                                          return Text('');
-                                        }
-                                        if (result1.hasException) {
-                                          return Text(
-                                              result1.exception.toString());
-                                        }
-                                        if (result1.loading) {
-                                          return Text('');
-                                        }
-                                        return Wrap(
-                                          spacing: 2,
-                                          children: getServicelistingButtons(result1.data["civicrmContactById"]),
-                                        );
-                                      }),
-                                ]
-                            )
-                          ]
-                      ),
+                        Divider(
+                          color: Color.fromRGBO(171, 173, 0, 100),
+                          thickness: 3,
+                          endIndent: MediaQuery.of(context).size.width * 0.70,
+                        ),
+                      ]
                     ),
-                    ListTile(
-                      subtitle: Table(
-                        columnWidths: {
-                          0: FlexColumnWidth(5),
-                          1: FlexColumnWidth(0.5),
-                        },
+                  ),
+                  subtitle: Wrap(
+                    children: [
+                      Row(
                         children: [
-                          TableRow(
-                            children: [
-                              TableCell(child: Text(
-                                getDescription(item),
-                                style: TextStyle(
-                                    color: Colors.grey[850],
-                                    fontSize: 15.0
-                                ),)
-                              ),
-                              TableCell(
-                                  child: new IconButton(
-                                    icon: new Icon(Icons.arrow_right),
-                                    onPressed: () {
-                                      var path = '';
-                                      var type = getType(item, true);
-                                      if (type == 'Service Listing') {
-                                        Navigator.push(
-                                              context,
-                                              MaterialPageRoute(
-                                                builder: (context) => new FullResultsPage(id: getItemId(item).toString())
-                                              )
-                                        );
-                                      }
-                                      else {
-                                        if (type == 'Event') {
-                                          path = 'civicrm/event/info?id=';
-                                        }
-                                        else {
-                                          path = 'node/';
-                                        }
-                                        launch(baseURL + path + getItemId(item).toString());
-                                      }
-                                    },
-                                  )
-                              )
-                            ]
-                          )
-                        ],
+                          Text(
+                            getTranslatedTitle(translation, getType(item, false)).toUpperCase(),
+                            style: TextStyle(
+                              color: Colors.grey[850],
+                              fontStyle: FontStyle.italic,
+                              fontSize: 12.0
+                            ),
+                          ),
+                          Text(' '),
+                          Query(
+                            options: QueryOptions(
+                             documentNode: gql(getServiceListingInformationQuery),
+                              variables: {"contact_id": serviceListingID, "contactId": serviceListingID}
+                            ),
+                            builder: (QueryResult result1, {VoidCallback refetch, FetchMore fetchMore}) {
+                              if (serviceListingID == "0") {
+                                return Text('');
+                              }
+                              if (result1.hasException) {
+                                return Text(result1.exception.toString());
+                              }
+                              if (result1.loading) {
+                                return Text('');
+                              }
+                              return Wrap(
+                                spacing: 2,
+                                children: getServicelistingButtons(
+                                  result1.data["civicrmContactById"]),
+                              );
+                            }
+                          ),
+                        ]
                       )
-                    ),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: geolocationButtons(item, translation),
-                    ),
-                  ],
-                )
-              )
-            );
-          });
+                    ]
+                  ),
+                ),
+                ListTile(
+                  subtitle: Table(
+                    columnWidths: {
+                      0: FlexColumnWidth(5),
+                      1: FlexColumnWidth(0.5),
+                    },
+                    children: [
+                      TableRow(
+                        children: [
+                          TableCell(
+                            child: Text(
+                              getDescription(item),
+                              style: TextStyle(
+                                color: Colors.grey[850],
+                                fontSize: 15.0
+                              ),
+                            )
+                          ),
+                          TableCell(
+                            child: new IconButton(
+                              icon: new Icon(Icons.arrow_right),
+                              onPressed: () {
+                                var path = '';
+                                var type = getType(item, true);
+                                if (type == 'Service Listing') {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => new FullResultsPage(id: getItemId(item).toString())
+                                    )
+                                  );
+                                }
+                                else {
+                                  if (type == 'Event') {
+                                    path = 'civicrm/event/info?id=';
+                                  }
+                                  else {
+                                    path = 'node/';
+                                  }
+                                  launch(baseURL + path + getItemId(item).toString());
+                                }
+                              },
+                            )
+                          )
+                        ]
+                      )
+                    ],
+                  )
+                ),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: geolocationButtons(item, translation),
+                ),
+              ],
+            )
+          )
+        );
+      }
+    );
 
   }
 
@@ -400,7 +417,8 @@ class Result extends StatelessWidget {
                 ),
               ),
             )
-          ));
+          )
+        );
       }
     }
     else {
@@ -413,14 +431,14 @@ class Result extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: 0.0),
       child: Align(
-          alignment: Alignment.centerLeft,
-          child: Text(
-            text,
-            style: TextStyle(
-              color: Colors.grey[850],
-              fontSize: 18.0
-            ),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          text,
+          style: TextStyle(
+            color: Colors.grey[850],
+            fontSize: 18.0
           ),
+        ),
       )
     );
   }
@@ -438,7 +456,6 @@ class Result extends StatelessWidget {
   getTitle(item) {
     var title = item['title'] ?? item["organization_name"] ?? item['tm_x3b_und_title_1'] ?? '';
     title = title.replaceAll('Self-employed ', '');
-
     return title;
   }
 
@@ -449,8 +466,8 @@ class Result extends StatelessWidget {
 
   String truncateWithEllipsis(int cutoff, String myString) {
     return (myString.length <= cutoff)
-        ? myString
-        : '${myString.substring(0, cutoff)}...';
+      ? myString
+      : '${myString.substring(0, cutoff)}...';
   }
 
   getItemId(item) {
@@ -493,7 +510,7 @@ class Result extends StatelessWidget {
     }
   }
 
-  String getbaseUrl(languageCode) {
+  String getBaseUrl(languageCode) {
     var baseURL = 'https://www.autismontario.com/';
     if (languageCode == 'FR') {
       baseURL = baseURL + 'fr/';

--- a/lib/src/ui/search_results.dart
+++ b/lib/src/ui/search_results.dart
@@ -80,7 +80,7 @@ class _SearchResultsState extends State<SearchResults> {
       builder: (QueryResult result, {VoidCallback refetch, FetchMore fetchMore}) {
         return Column(
           children: [
-            legendIconBlock(translation),
+            legendIconBlock(translation, context),
             Container(
               child: result.hasException
                 ? Text(result.exception.toString())
@@ -95,7 +95,7 @@ class _SearchResultsState extends State<SearchResults> {
   }
 }
 
-  Widget legendIconBlock(translation) {
+  Widget legendIconBlock(translation, context) {
     const rowSpacer=TableRow(
       children: [
         SizedBox(
@@ -114,7 +114,8 @@ class _SearchResultsState extends State<SearchResults> {
           children: [
             SizedBox(height: 10.0),
             Table(
-              children: [
+                defaultColumnWidth: MediaQuery.of(context).size.width > 400 ? FixedColumnWidth(400.0) : FixedColumnWidth(170.0),
+                children: [
                 TableRow(
                   children: [
                     TableCell(
@@ -140,6 +141,7 @@ class _SearchResultsState extends State<SearchResults> {
                   children: [
                     TableCell(
                       child: Column(
+
                         children: [
                           Image.asset('images/icon_videoconferencing_16px.png'),
                           Text(translation.online),
@@ -171,7 +173,7 @@ class _SearchResultsState extends State<SearchResults> {
                       child: Column(
                         children: [
                           Image.asset('images/icon_verified_16px.png'),
-                          Text(translation.verifiedListing),
+                          Text(translation.verifiedListing, textAlign: TextAlign.right),
                         ],
                       )
                     ),


### PR DESCRIPTION
@JoeMurray @seamuslee001 currently the patch moves the Catagory widget and Reset button out of the Advance Search form. And here's how it look now:
![Screenshot_1608164511](https://user-images.githubusercontent.com/3735621/102422258-5c86aa00-402c-11eb-90cd-f0987449ecf1.png)

But, how about we show list of checkboxes instead of mult-select widget: 
![Screenshot_1608164004](https://user-images.githubusercontent.com/3735621/102422336-8c35b200-402c-11eb-999d-bd25bbebfeb7.png)

 